### PR TITLE
okhttp: Use "api" instead of "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ See [Using JSON Web Tokens](https://github.com/zensum/documentation/tree/master/
 
 ## Usage
 
-Add to `build.gradle`:
+Add to `build.gradle(.kts)`:
 ```gradle
-implementation("com.github.zensum:auth0-m2m.library:566d4a2")
-implementation("com.squareup.okhttp3:okhttp:3.14.2")
+implementation("com.github.zensum:auth0-m2m.library:ef2ea10")
 ```
 
 Minimal example for using [Auth0TokenService](src/main/kotlin/io/klira/auth0/m2m/Auth0TokenService.kt) and doing a request.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ object Version {
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "1.3.21" apply true
-    id("java") apply true
+    id("java-library") apply true
     id("maven") apply true
     id("idea") apply true
 }
@@ -40,7 +40,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module", "jackson-module-kotlin", Version.JACKSON)
     implementation("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", Version.JACKSON)
 
-    implementation("com.squareup.okhttp3:okhttp:3.14.2")
+    api("com.squareup.okhttp3:okhttp:3.14.2")
     implementation("com.auth0", "java-jwt", "3.7.0")
 
     // Junit


### PR DESCRIPTION
Use api instead of implementation so dependency OkHttp is properly
exposed, since it is needed either way by consumers of this library.